### PR TITLE
Add support to msys2/mingw 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
             mingw-w64-x86_64-nodejs
             mingw-w64-x86_64-python
             mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-make
+            make
 
       - name: Verify MinGW Node.js is active
         shell: msys2 {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,38 @@ jobs:
       - name: Prebuild
         shell: bash
         run: npm run prebuild
+
+  test-mingw:
+    name: Test MinGW (MSYS2 MINGW64) on Windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2 with MINGW64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-nodejs
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-make
+
+      - name: Verify MinGW Node.js is active
+        shell: msys2 {0}
+        run: node -e "const os = require('os'); console.log('os.type():', os.type()); if (!os.type().startsWith('MINGW')) process.exit(1)"
+
+      - name: Install dependencies
+        shell: msys2 {0}
+        run: npm install
+
+      - name: Build native tests
+        shell: msys2 {0}
+        run: npm run build
+
+      - name: Run tests
+        shell: msys2 {0}
+        run: npm test

--- a/deps/libffi/libffi.gyp
+++ b/deps/libffi/libffi.gyp
@@ -9,10 +9,13 @@
 {
   'variables': {
     'target_arch%': 'ia32', # built for a 32-bit CPU by default
-    # Distinguish MSVC from MinGW/MSYS2 on Windows. MinGW reports an OS type
-    # starting with "MINGW" and uses GCC toolchain, so .S files compile directly
+    # Distinguish MSVC from MinGW/MSYS2 on Windows. MinGW-compiled Node reports
+    # an OS type starting with "MINGW", but MSYS2 subsystems like UCRT64 ship a
+    # Windows-native Node where os.type() returns "Windows_NT". In both cases
+    # MSYS2 sets the MSYSTEM env var (MINGW32, MINGW64, UCRT64, CLANG64, …).
+    # Either signal means GCC is the toolchain, so .S files compile directly
     # without the MSVC-specific preprocess_asm.cmd pre-processing step.
-    'target_platform%': '<!(node -p "require(\'os\').type().startsWith(\'MINGW\') ? \'mingw\' : (process.platform === \'win32\' ? \'msvc\' : \'\')")',
+    'target_platform%': '<!(node -p "require(\'os\').type().startsWith(\'MINGW\') || process.env.MSYSTEM ? \'mingw\' : (process.platform === \'win32\' ? \'msvc\' : \'\')")',
   },
   'target_defaults': {
     'default_configuration': 'Debug',

--- a/deps/libffi/libffi.gyp
+++ b/deps/libffi/libffi.gyp
@@ -9,6 +9,10 @@
 {
   'variables': {
     'target_arch%': 'ia32', # built for a 32-bit CPU by default
+    # Distinguish MSVC from MinGW/MSYS2 on Windows. MinGW reports an OS type
+    # starting with "MINGW" and uses GCC toolchain, so .S files compile directly
+    # without the MSVC-specific preprocess_asm.cmd pre-processing step.
+    'target_platform%': '<!(node -p "require(\'os\').type().startsWith(\'MINGW\') ? \'mingw\' : (process.platform === \'win32\' ? \'msvc\' : \'\')")',
   },
   'target_defaults': {
     'default_configuration': 'Debug',
@@ -50,9 +54,10 @@
     ],
   },
 
-  # Compile .S files on Windows
+  # MSVC-specific rules for preprocessing .preasm -> .asm -> .obj.
+  # MinGW uses GCC and compiles .S files directly without these rules.
   'conditions': [
-    ['OS=="win"', {
+    ['OS=="win" and target_platform=="msvc"', {
       'target_defaults': {
         'conditions': [
           ['target_arch=="ia32"', {
@@ -151,8 +156,11 @@
             ['OS=="linux" or OS=="mac"', {
               'sources': [ 'src/aarch64/sysv.S' ]
             }],
-            ['OS=="win"', {
+            ['OS=="win" and target_platform=="msvc"', {
               'sources': [ 'src/aarch64/win64_armasm.preasm' ]
+            }],
+            ['OS=="win" and target_platform=="mingw"', {
+              'sources': [ 'src/aarch64/sysv.S' ]
             }],
           ]
         }, { # ia32 or x64
@@ -160,29 +168,39 @@
             ['target_arch=="ia32"', {
               'sources': [ 'src/x86/ffi.c' ],
               'conditions': [
-                ['OS=="win"', {
+                ['OS=="win" and target_platform=="msvc"', {
                   'sources': [ 'src/x86/sysv_intel.preasm' ],
-                }, {
+                }],
+                ['OS=="win" and target_platform=="mingw"', {
+                  'sources': [ 'src/x86/sysv.S' ],
+                }],
+                ['OS!="win"', {
                   'sources': [ 'src/x86/sysv.S' ],
                 }],
               ],
             }],
             ['target_arch=="x64"', {
-              'sources': [
-                'src/x86/ffiw64.c',
-              ],
               'conditions': [
-                ['OS=="win"', {
+                ['OS=="win" and target_platform=="msvc"', {
                   'sources': [
+                    'src/x86/ffiw64.c',
                     'src/x86/win64_intel.preasm',
                   ],
-                }, {
+                  'msvs_disabled_warnings': [ 4267 ],
+                }],
+                ['OS=="win" and target_platform=="mingw"', {
+                  'sources': [
+                    'src/x86/ffiw64.c',
+                    'src/x86/win64.S',
+                  ],
+                }],
+                ['OS!="win"', {
                   'sources': [
                     'src/x86/ffi64.c',
                     'src/x86/unix64.S',
                     'src/x86/win64.S',
                   ],
-                }]
+                }],
               ],
             }],
             ['target_arch=="s390x"', {
@@ -190,11 +208,6 @@
                 'src/s390/ffi.c',
                 'src/s390/sysv.S',
               ],
-            }],
-            ['OS=="win"', {
-              # the libffi dlmalloc.c file has a bunch of implicit conversion
-              # warnings, and the main ffi.c file contains one, so silence them
-              'msvs_disabled_warnings': [ 4267 ],
             }],
           ]
         }],

--- a/deps/libffi/libffi.gyp
+++ b/deps/libffi/libffi.gyp
@@ -11,11 +11,12 @@
     'target_arch%': 'ia32', # built for a 32-bit CPU by default
     # Distinguish MSVC from MinGW/MSYS2 on Windows. MinGW-compiled Node reports
     # an OS type starting with "MINGW", but MSYS2 subsystems like UCRT64 ship a
-    # Windows-native Node where os.type() returns "Windows_NT". In both cases
-    # MSYS2 sets the MSYSTEM env var (MINGW32, MINGW64, UCRT64, CLANG64, …).
-    # Either signal means GCC is the toolchain, so .S files compile directly
-    # without the MSVC-specific preprocess_asm.cmd pre-processing step.
-    'target_platform%': '<!(node -p "require(\'os\').type().startsWith(\'MINGW\') || process.env.MSYSTEM ? \'mingw\' : (process.platform === \'win32\' ? \'msvc\' : \'\')")',
+    # Windows-native Node where os.type() returns "Windows_NT". Real MSYS2 sets
+    # MSYSTEM_PREFIX (e.g. /mingw64, /ucrt64); Git for Windows also sets MSYSTEM
+    # but does NOT set MSYSTEM_PREFIX, so we use that to avoid false positives
+    # in Git Bash environments. Either signal means GCC is the toolchain, so .S
+    # files compile directly without the MSVC preprocess_asm.cmd step.
+    'target_platform%': '<!(node -p "require(\'os\').type().startsWith(\'MINGW\') || process.env.MSYSTEM_PREFIX ? \'mingw\' : (process.platform === \'win32\' ? \'msvc\' : \'\')")',
   },
   'target_defaults': {
     'default_configuration': 'Debug',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@napi-ffi/ffi-napi",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@napi-ffi/ffi-napi",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@napi-ffi/get-uv-event-loop-napi-h": "^1.0.6",
-        "@napi-ffi/ref-napi": "^3.0.6",
+        "@napi-ffi/ref-napi": "^3.0.7",
         "@napi-ffi/ref-struct-di": "^1.1.1",
         "debug": "^4.3.7",
         "node-addon-api": "^8.2.1",
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@napi-ffi/ref-napi": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@napi-ffi/ref-napi/-/ref-napi-3.0.6.tgz",
-      "integrity": "sha512-xR+sxG/DzV+g/xbSHlrjAQkzJoR/+uL6RGde5SR2cGQqj/WO9A93gBypYtcdfnsnUOgNOeyfiUU9TRKatxD9cA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-ffi/ref-napi/-/ref-napi-3.0.7.tgz",
+      "integrity": "sha512-oCaKehZERf2mEnqTJnxv/2hNDT5CpCH3s4jqncbi8jfSp40ydjhWk/xkuBz3GuSoCWeMW2y3EvFQS+sNDrfnug==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@napi-ffi/ffi-napi",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "license": "MIT",
   "author": "Anna Henningsen <anna@addaleax.net>",
   "contributors": [
@@ -33,7 +33,7 @@
     "@napi-ffi/get-uv-event-loop-napi-h": "^1.0.6",
     "node-addon-api": "^8.2.1",
     "node-gyp-build": "^4.8.2",
-    "@napi-ffi/ref-napi": "^3.0.6",
+    "@napi-ffi/ref-napi": "^3.0.7",
     "@napi-ffi/ref-struct-di": "^1.1.1"
   },
   "devDependencies": {

--- a/test/library.js
+++ b/test/library.js
@@ -21,19 +21,22 @@ describe('Library', function () {
   });
 
   it('should accept `null` as a first argument', function () {
-    if (process.platform == 'win32') {
-      // On Windows, null refers to just the main executable (e.g. node.exe).
-      // Windows never searches for symbols across multiple DLL's.
-      // Note: Exporting symbols from an executable is unusual on Windows.
-      // Normally you only see exports from DLL's. It happens that node.exe
-      // does export symbols, so null as a first argument can be tested.
-      // This is an implementation detail of node, and could potentially
-      // change in the future (e.g. if node gets broken up into DLL's
-      // rather than being one large static linked executable).
+    if (process.platform == 'win32' && !process.env.MSYSTEM_PREFIX) {
+      // On Windows (MSVC builds), null refers to just the main executable
+      // (e.g. node.exe). Windows never searches for symbols across DLLs.
+      // node.exe happens to export uv_fs_open, so null can be tested here.
+      // This is an implementation detail of node that does not hold for
+      // MSYS2/MinGW builds where libuv may be a separate DLL or symbols
+      // are not re-exported from the node binary.
       const winFuncs = new Library(null, {
         'uv_fs_open': [ 'void', [ charPtr ] ]
       });
       assert(typeof winFuncs.uv_fs_open === 'function');
+    } else if (process.platform == 'win32') {
+      // MinGW/MSYS2: null is supported but uv_fs_open is not guaranteed
+      // to be exported from the node binary, skip the symbol check.
+      const l = new Library(null, {});
+      assert(typeof l === 'object');
     } else {
       // On POSIX, null refers to the global symbol table, and lets you use
       // symbols in the main executable and loaded shared libaries.


### PR DESCRIPTION
Fixes build failures when installing `@napi-ffi/ffi-napi` from source under MSYS2 subsystems on Windows.

Adds a dedicated MinGW (MSYS2 MINGW64) job to `ci.yml`.

Closes #1 